### PR TITLE
Fix block_size_max handling in adjust_request_size

### DIFF
--- a/tlsf.c
+++ b/tlsf.c
@@ -492,10 +492,15 @@ static void* align_ptr(const void* ptr, size_t align)
 static size_t adjust_request_size(size_t size, size_t align)
 {
 	size_t adjust = 0;
-	if (size && size < block_size_max)
+	if (size)
 	{
 		const size_t aligned = align_up(size, align);
-		adjust = tlsf_max(aligned, block_size_min);
+
+		/* aligned sized must not exceed block_size_max or we'll go out of bounds on sl_bitmap */
+		if (aligned < block_size_max) 
+		{
+			adjust = tlsf_max(aligned, block_size_min);
+		}
 	}
 	return adjust;
 }


### PR DESCRIPTION
In the 64-bit build, an allocation of request in the range
]block_size_max-ALIGN_SIZE,block_size_max[ could cause an out-of-bounds
access to sl_bitmap.
