### PR TITLE
Fix warnining on implicit pointer conversion.

### DIFF
--- a/tlsf.c
+++ b/tlsf.c
@@ -898,7 +898,7 @@ int tlsf_check(tlsf_t tlsf)
 static void default_walker(void* ptr, size_t size, int used, void* user)
 {
 	(void)user;
-	printf("\t%p %s size: %x (%p)\n", ptr, used ? "used" : "free", (unsigned int)size, block_from_ptr(ptr));
+	printf("\t%p %s size: %x (%p)\n", ptr, used ? "used" : "free", (unsigned int)size, (void *)block_from_ptr(ptr));
 }
 
 void tlsf_walk_pool(pool_t pool, tlsf_walker walker, void* user)


### PR DESCRIPTION
GCC emits a warning when using "%p" with a pointer that is not void. This is a problem for people compiling with "all warnings are errors". A cast solves the issue.