### PR TITLE
set control block at runtime

### DIFF
--- a/tlsf.c
+++ b/tlsf.c
@@ -234,20 +234,10 @@ enum tlsf_private
 	** blocks below that size into the 0th first-level list.
 	*/
 
-#if defined (TLSF_64BIT)
-	/*
-	** TODO: We can increase this to support larger sizes, at the expense
-	** of more overhead in the TLSF structure.
-	*/
-	FL_INDEX_MAX = 32,
-#else
-	FL_INDEX_MAX = 30,
-#endif
-	SL_INDEX_COUNT = (1 << SL_INDEX_COUNT_LOG2),
-	FL_INDEX_SHIFT = (SL_INDEX_COUNT_LOG2 + ALIGN_SIZE_LOG2),
-	FL_INDEX_COUNT = (FL_INDEX_MAX - FL_INDEX_SHIFT + 1),
-
-	SMALL_BLOCK_SIZE = (1 << FL_INDEX_SHIFT),
+	SL_INDEX_COUNT_LOG2_MIN,
+	FL_INDEX_MAX_MIN = 15,
+	SL_INDEX_COUNT_MIN = (1 << SL_INDEX_COUNT_LOG2_MIN),
+	FL_INDEX_COUNT_MIN = (FL_INDEX_MAX_MIN - (SL_INDEX_COUNT_LOG2_MIN + ALIGN_SIZE_LOG2) + 1),
 };
 
 /*
@@ -278,12 +268,6 @@ enum tlsf_private
 tlsf_static_assert(sizeof(int) * CHAR_BIT == 32);
 tlsf_static_assert(sizeof(size_t) * CHAR_BIT >= 32);
 tlsf_static_assert(sizeof(size_t) * CHAR_BIT <= 64);
-
-/* SL_INDEX_COUNT must be <= number of bits in sl_bitmap's storage type. */
-tlsf_static_assert(sizeof(unsigned int) * CHAR_BIT >= SL_INDEX_COUNT);
-
-/* Ensure we've properly tuned our sizes. */
-tlsf_static_assert(ALIGN_SIZE == SMALL_BLOCK_SIZE / SL_INDEX_COUNT);
 
 /*
 ** Data structures and associated constants.
@@ -338,8 +322,6 @@ static const size_t block_start_offset =
 */
 static const size_t block_size_min = 
 	sizeof(block_header_t) - sizeof(block_header_t*);
-static const size_t block_size_max = tlsf_cast(size_t, 1) << FL_INDEX_MAX;
-
 
 /* The TLSF control structure. */
 typedef struct control_t
@@ -347,12 +329,21 @@ typedef struct control_t
 	/* Empty lists point at this block to indicate they are free. */
 	block_header_t block_null;
 
+	/* Local parameter for the pool */
+	unsigned int fl_index_count;
+	unsigned int fl_index_shift;
+	unsigned int fl_index_max;
+	unsigned int sl_index_count;
+	unsigned int sl_index_count_log2;
+	unsigned int small_block_size;
+	size_t size;
+
 	/* Bitmaps for free lists. */
 	unsigned int fl_bitmap;
-	unsigned int sl_bitmap[FL_INDEX_COUNT];
+	unsigned int *sl_bitmap;
 
 	/* Head of free lists. */
-	block_header_t* blocks[FL_INDEX_COUNT][SL_INDEX_COUNT];
+	block_header_t** blocks;
 } control_t;
 
 /* A type used for casting when doing pointer arithmetic. */
@@ -361,6 +352,12 @@ typedef ptrdiff_t tlsfptr_t;
 /*
 ** block_header_t member functions.
 */
+
+static size_t block_size_max(tlsf_t tlsf)
+{
+	control_t* control = tlsf_cast(control_t*, tlsf);
+	return tlsf_cast(size_t, 1) << control->fl_index_max;
+}
 
 static size_t block_size(const block_header_t* block)
 {
@@ -489,7 +486,7 @@ static void* align_ptr(const void* ptr, size_t align)
 ** Adjust an allocation size to be aligned to word size, and no smaller
 ** than internal minimum.
 */
-static size_t adjust_request_size(size_t size, size_t align)
+static size_t adjust_request_size(tlsf_t tlsf, size_t size, size_t align)
 {
 	size_t adjust = 0;
 	if (size)
@@ -497,7 +494,7 @@ static size_t adjust_request_size(size_t size, size_t align)
 		const size_t aligned = align_up(size, align);
 
 		/* aligned sized must not exceed block_size_max or we'll go out of bounds on sl_bitmap */
-		if (aligned < block_size_max) 
+		if (aligned < tlsf_block_size_max(tlsf))
 		{
 			adjust = tlsf_max(aligned, block_size_min);
 		}
@@ -510,34 +507,34 @@ static size_t adjust_request_size(size_t size, size_t align)
 ** the documentation found in the white paper.
 */
 
-static void mapping_insert(size_t size, int* fli, int* sli)
+static void mapping_insert(control_t *control, size_t size, int* fli, int* sli)
 {
 	int fl, sl;
-	if (size < SMALL_BLOCK_SIZE)
+	if (size < control->small_block_size)
 	{
 		/* Store small blocks in first list. */
 		fl = 0;
-		sl = tlsf_cast(int, size) / (SMALL_BLOCK_SIZE / SL_INDEX_COUNT);
+		sl = tlsf_cast(int, size) / (control->small_block_size / control->sl_index_count);
 	}
 	else
 	{
 		fl = tlsf_fls_sizet(size);
-		sl = tlsf_cast(int, size >> (fl - SL_INDEX_COUNT_LOG2)) ^ (1 << SL_INDEX_COUNT_LOG2);
-		fl -= (FL_INDEX_SHIFT - 1);
+		sl = tlsf_cast(int, size >> (fl - control->sl_index_count_log2)) ^ (1 << control->sl_index_count_log2);
+		fl -= (control->fl_index_shift - 1);
 	}
 	*fli = fl;
 	*sli = sl;
 }
 
 /* This version rounds up to the next block size (for allocations) */
-static void mapping_search(size_t size, int* fli, int* sli)
+static void mapping_search(control_t *control, size_t size, int* fli, int* sli)
 {
-	if (size >= SMALL_BLOCK_SIZE)
+	if (size >= control->small_block_size)
 	{
-		const size_t round = (1 << (tlsf_fls_sizet(size) - SL_INDEX_COUNT_LOG2)) - 1;
+		const size_t round = (1 << (tlsf_fls_sizet(size) - control->sl_index_count_log2)) - 1;
 		size += round;
 	}
-	mapping_insert(size, fli, sli);
+	mapping_insert(control, size, fli, sli);
 }
 
 static block_header_t* search_suitable_block(control_t* control, int* fli, int* sli)
@@ -569,7 +566,7 @@ static block_header_t* search_suitable_block(control_t* control, int* fli, int* 
 	*sli = sl;
 
 	/* Return the first block in the free list. */
-	return control->blocks[fl][sl];
+	return control->blocks[fl*control->sl_index_count + sl];
 }
 
 /* Remove a free block from the free list.*/
@@ -583,9 +580,9 @@ static void remove_free_block(control_t* control, block_header_t* block, int fl,
 	prev->next_free = next;
 
 	/* If this block is the head of the free list, set new head. */
-	if (control->blocks[fl][sl] == block)
+	if (control->blocks[fl*control->sl_index_count + sl] == block)
 	{
-		control->blocks[fl][sl] = next;
+		control->blocks[fl*control->sl_index_count + sl] = next;
 
 		/* If the new head is null, clear the bitmap. */
 		if (next == &control->block_null)
@@ -604,7 +601,7 @@ static void remove_free_block(control_t* control, block_header_t* block, int fl,
 /* Insert a free block into the free block list. */
 static void insert_free_block(control_t* control, block_header_t* block, int fl, int sl)
 {
-	block_header_t* current = control->blocks[fl][sl];
+	block_header_t* current = control->blocks[fl*control->sl_index_count + sl];
 	tlsf_assert(current && "free list cannot have a null entry");
 	tlsf_assert(block && "cannot insert a null entry into the free list");
 	block->next_free = current;
@@ -617,7 +614,7 @@ static void insert_free_block(control_t* control, block_header_t* block, int fl,
 	** Insert the new block at the head of the list, and mark the first-
 	** and second-level bitmaps appropriately.
 	*/
-	control->blocks[fl][sl] = block;
+	control->blocks[fl*control->sl_index_count + sl] = block;
 	control->fl_bitmap |= (1U << fl);
 	control->sl_bitmap[fl] |= (1U << sl);
 }
@@ -626,7 +623,7 @@ static void insert_free_block(control_t* control, block_header_t* block, int fl,
 static void block_remove(control_t* control, block_header_t* block)
 {
 	int fl, sl;
-	mapping_insert(block_size(block), &fl, &sl);
+	mapping_insert(control, block_size(block), &fl, &sl);
 	remove_free_block(control, block, fl, sl);
 }
 
@@ -634,7 +631,7 @@ static void block_remove(control_t* control, block_header_t* block)
 static void block_insert(control_t* control, block_header_t* block)
 {
 	int fl, sl;
-	mapping_insert(block_size(block), &fl, &sl);
+	mapping_insert(control, block_size(block), &fl, &sl);
 	insert_free_block(control, block, fl, sl);
 }
 
@@ -757,7 +754,7 @@ static block_header_t* block_locate_free(control_t* control, size_t size)
 
 	if (size)
 	{
-		mapping_search(size, &fl, &sl);
+		mapping_search(control, size, &fl, &sl);
 		
 		/*
 		** mapping_search can futz with the size, so for excessively large sizes it can sometimes wind up 
@@ -765,7 +762,7 @@ static block_header_t* block_locate_free(control_t* control, size_t size)
 		** So, we protect against that here, since this is the only callsite of mapping_search.
 		** Note that we don't need to check sl, since it comes from a modulo operation that guarantees it's always in range.
 		*/
-		if (fl < FL_INDEX_COUNT)
+		if (fl < control->fl_index_count)
 		{
 			block = search_suitable_block(control, &fl, &sl);
 		}
@@ -794,20 +791,44 @@ static void* block_prepare_used(control_t* control, block_header_t* block, size_
 }
 
 /* Clear structure and point all empty lists at the null block. */
-static void control_construct(control_t* control)
+static void control_construct(control_t* control, size_t bytes)
 {
 	int i, j;
 
 	control->block_null.next_free = &control->block_null;
 	control->block_null.prev_free = &control->block_null;
 
+	/* find the closest ^2 for first layer */
+	i = (bytes - 1) / (16 * 1024);
+	control->fl_index_max = FL_INDEX_MAX_MIN + tlsf_fls(i);
+
+	/* adapt second layer to the pool */
+	if (bytes <= 16 * 1024) control->sl_index_count_log2 = 3;
+	else if (bytes <= 256 * 1024) control->sl_index_count_log2 = 4;
+	else control->sl_index_count_log2 = 5;
+
+	control->fl_index_shift = (control->sl_index_count_log2 + ALIGN_SIZE_LOG2);
+	control->sl_index_count = 1 << control->sl_index_count_log2;
+	control->fl_index_count = control->fl_index_max - control->fl_index_shift + 1;
+	control->small_block_size = 1 << control->fl_index_shift;
 	control->fl_bitmap = 0;
-	for (i = 0; i < FL_INDEX_COUNT; ++i)
+
+	control->sl_bitmap = align_ptr(control + 1, sizeof(*control->sl_bitmap));
+	control->blocks = align_ptr(control->sl_bitmap + control->fl_index_count, sizeof(*control->blocks));
+	control->size = (char*) (control->blocks + control->sl_index_count * control->fl_index_count) - (char*) control;
+	
+	/* SL_INDEX_COUNT must be <= number of bits in sl_bitmap's storage type. */
+	tlsf_assert(sizeof(unsigned int) * CHAR_BIT >= control->sl_index_count && "CHAR_BIT less than sl_index_count");
+
+	/* Ensure we've properly tuned our sizes. */
+	tlsf_assert(ALIGN_SIZE == control->small_block_size / control->sl_index_count && "ALIGN_SIZE does not match");
+	
+	for (i = 0; i < control->fl_index_count; ++i)
 	{
 		control->sl_bitmap[i] = 0;
-		for (j = 0; j < SL_INDEX_COUNT; ++j)
+		for (j = 0; j < control->sl_index_count; ++j)
 		{
-			control->blocks[i][j] = &control->block_null;
+			control->blocks[i*control->sl_index_count + j] = &control->block_null;
 		}
 	}
 }
@@ -849,14 +870,14 @@ int tlsf_check(tlsf_t tlsf)
 	int status = 0;
 
 	/* Check that the free lists and bitmaps are accurate. */
-	for (i = 0; i < FL_INDEX_COUNT; ++i)
+	for (i = 0; i < control->fl_index_count; ++i)
 	{
-		for (j = 0; j < SL_INDEX_COUNT; ++j)
+		for (j = 0; j < control->sl_index_count; ++j)
 		{
 			const int fl_map = control->fl_bitmap & (1U << i);
 			const int sl_list = control->sl_bitmap[i];
 			const int sl_map = sl_list & (1U << j);
-			const block_header_t* block = control->blocks[i][j];
+			const block_header_t* block = control->blocks[i*control->sl_index_count + j];
 
 			/* Check that first- and second-level lists agree. */
 			if (!fl_map)
@@ -883,7 +904,7 @@ int tlsf_check(tlsf_t tlsf)
 				tlsf_insist(block_is_prev_free(block_next(block)) && "block should be free");
 				tlsf_insist(block_size(block) >= block_size_min && "block not minimum size");
 
-				mapping_insert(block_size(block), &fli, &sli);
+				mapping_insert(control, block_size(block), &fli, &sli);
 				tlsf_insist(fli == i && sli == j && "block size indexed in wrong list");
 				block = block->next_free;
 			}
@@ -938,13 +959,36 @@ int tlsf_check_pool(pool_t pool)
 	return integ.status;
 }
 
+size_t tlsf_fit_size(tlsf_t tlsf, size_t size)
+{
+	/* because it's GoodFit, allocable size is one range lower */
+	if (size)
+	{
+		size_t sl_interval;
+		control_t* control = tlsf_cast(control_t*, tlsf);
+		sl_interval = (1 << tlsf_fls(size)) / control->sl_index_count;
+		return size & ~(sl_interval - 1);
+	}
+
+	return 0;
+}
+
 /*
 ** Size of the TLSF structures in a given memory block passed to
 ** tlsf_create, equal to the size of a control_t
 */
-size_t tlsf_size(void)
+size_t tlsf_size(tlsf_t tlsf)
 {
-	return sizeof(control_t);
+	if (tlsf) 
+	{
+		control_t* control = tlsf_cast(control_t*, tlsf);
+		return control->size;
+	}	
+	
+	/* no tlsf, we'll just return a min size */
+	return sizeof(control_t) + 
+	       sizeof(int) * SL_INDEX_COUNT_MIN + 
+	       sizeof(block_header_t*) * SL_INDEX_COUNT_MIN * FL_INDEX_COUNT_MIN;
 }
 
 size_t tlsf_align_size(void)
@@ -957,9 +1001,10 @@ size_t tlsf_block_size_min(void)
 	return block_size_min;
 }
 
-size_t tlsf_block_size_max(void)
+size_t tlsf_block_size_max(tlsf_t tlsf)
 {
-	return block_size_max;
+	control_t* control = tlsf_cast(control_t*, tlsf);
+	return tlsf_cast(size_t, 1) << control->fl_index_max;
 }
 
 /*
@@ -992,16 +1037,16 @@ pool_t tlsf_add_pool(tlsf_t tlsf, void* mem, size_t bytes)
 		return 0;
 	}
 
-	if (pool_bytes < block_size_min || pool_bytes > block_size_max)
+	if (pool_bytes < block_size_min || pool_bytes > tlsf_block_size_max(tlsf))
 	{
 #if defined (TLSF_64BIT)
 		printf("tlsf_add_pool: Memory size must be between 0x%x and 0x%x00 bytes.\n", 
 			(unsigned int)(pool_overhead + block_size_min),
-			(unsigned int)((pool_overhead + block_size_max) / 256));
+			(unsigned int)((pool_overhead + block_size_max(tlsf)) / 256));
 #else
-		printf("tlsf_add_pool: Memory size must be between %u and %u bytes.\n", 
+		printf("tlsf_add_pool: Memory size must be between %u and %u bytes.\n",
 			(unsigned int)(pool_overhead + block_size_min),
-			(unsigned int)(pool_overhead + block_size_max));
+			(unsigned int)(pool_overhead + block_size_max(tlsf)));
 #endif
 		return 0;
 	}
@@ -1037,7 +1082,7 @@ void tlsf_remove_pool(tlsf_t tlsf, pool_t pool)
 	tlsf_assert(!block_is_free(block_next(block)) && "next block should not be free");
 	tlsf_assert(block_size(block_next(block)) == 0 && "next block size should be zero");
 
-	mapping_insert(block_size(block), &fl, &sl);
+	mapping_insert(control, block_size(block), &fl, &sl);
 	remove_free_block(control, block, fl, sl);
 }
 
@@ -1073,7 +1118,7 @@ int test_ffs_fls()
 }
 #endif
 
-tlsf_t tlsf_create(void* mem)
+tlsf_t tlsf_create(void* mem, size_t max_bytes)
 {
 #if _DEBUG
 	if (test_ffs_fls())
@@ -1089,15 +1134,15 @@ tlsf_t tlsf_create(void* mem)
 		return 0;
 	}
 
-	control_construct(tlsf_cast(control_t*, mem));
+	control_construct(tlsf_cast(control_t*, mem), max_bytes);
 
 	return tlsf_cast(tlsf_t, mem);
 }
 
-tlsf_t tlsf_create_with_pool(void* mem, size_t bytes)
+tlsf_t tlsf_create_with_pool(void* mem, size_t pool_bytes, size_t max_bytes)
 {
-	tlsf_t tlsf = tlsf_create(mem);
-	tlsf_add_pool(tlsf, (char*)mem + tlsf_size(), bytes - tlsf_size());
+	tlsf_t tlsf = tlsf_create(mem, max_bytes ? max_bytes : pool_bytes);
+	tlsf_add_pool(tlsf, (char*)mem + tlsf_size(tlsf), pool_bytes - tlsf_size(tlsf));
 	return tlsf;
 }
 
@@ -1109,13 +1154,13 @@ void tlsf_destroy(tlsf_t tlsf)
 
 pool_t tlsf_get_pool(tlsf_t tlsf)
 {
-	return tlsf_cast(pool_t, (char*)tlsf + tlsf_size());
+	return tlsf_cast(pool_t, (char*)tlsf + tlsf_size(tlsf));
 }
 
 void* tlsf_malloc(tlsf_t tlsf, size_t size)
 {
 	control_t* control = tlsf_cast(control_t*, tlsf);
-	const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+	const size_t adjust = adjust_request_size(control, size, ALIGN_SIZE);
 	block_header_t* block = block_locate_free(control, adjust);
 	return block_prepare_used(control, block, adjust);
 }
@@ -1123,7 +1168,7 @@ void* tlsf_malloc(tlsf_t tlsf, size_t size)
 void* tlsf_memalign(tlsf_t tlsf, size_t align, size_t size)
 {
 	control_t* control = tlsf_cast(control_t*, tlsf);
-	const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+	const size_t adjust = adjust_request_size(control, size, ALIGN_SIZE);
 
 	/*
 	** We must allocate an additional minimum block size bytes so that if
@@ -1134,7 +1179,7 @@ void* tlsf_memalign(tlsf_t tlsf, size_t align, size_t size)
 	** the size of that block.
 	*/
 	const size_t gap_minimum = sizeof(block_header_t);
-	const size_t size_with_gap = adjust_request_size(adjust + align + gap_minimum, align);
+	const size_t size_with_gap = adjust_request_size(tlsf, adjust + align + gap_minimum, align);
 
 	/*
 	** If alignment is less than or equals base alignment, we're done.
@@ -1227,7 +1272,7 @@ void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size)
 
 		const size_t cursize = block_size(block);
 		const size_t combined = cursize + block_size(next) + block_header_overhead;
-		const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+		const size_t adjust = adjust_request_size(tlsf, size, ALIGN_SIZE);
 
 		tlsf_assert(!block_is_free(block) && "block already marked as free");
 

--- a/tlsf.h
+++ b/tlsf.h
@@ -50,8 +50,8 @@ typedef void* tlsf_t;
 typedef void* pool_t;
 
 /* Create/destroy a memory pool. */
-tlsf_t tlsf_create(void* mem);
-tlsf_t tlsf_create_with_pool(void* mem, size_t bytes);
+tlsf_t tlsf_create(void* mem, size_t max_bytes);
+tlsf_t tlsf_create_with_pool(void* mem, size_t pool_bytes, size_t max_bytes);
 void tlsf_destroy(tlsf_t tlsf);
 pool_t tlsf_get_pool(tlsf_t tlsf);
 
@@ -69,12 +69,13 @@ void tlsf_free(tlsf_t tlsf, void* ptr);
 size_t tlsf_block_size(void* ptr);
 
 /* Overheads/limits of internal structures. */
-size_t tlsf_size(void);
+size_t tlsf_size(tlsf_t tlsf);
 size_t tlsf_align_size(void);
 size_t tlsf_block_size_min(void);
-size_t tlsf_block_size_max(void);
+size_t tlsf_block_size_max(tlsf_t tlsf);
 size_t tlsf_pool_overhead(void);
 size_t tlsf_alloc_overhead(void);
+size_t tlsf_fit_size(tlsf_t tlsf, size_t size);
 
 /* Debugging. */
 typedef void (*tlsf_walker)(void* ptr, size_t size, int used, void* user);


### PR DESCRIPTION
This PR allows heap's control block to be dynamically calculated as a function of the size of the heap.

This is useful for embedded systems like espressif/esp-idf#7829 where there are a set of disparate size memory pools that cannot be combined together using tlsf_add_pool because they must be kept separated.

In such case, the control_t block has to be the size of the one for the largest heap and that can was a lot of (precious) memory for small heap, when much larger heaps exists. When creating a heap, the size of the expected heap can be added so that pools addition using tlsf_add_pool do not overflow the initially created control_block.

I don't think there is a large CPU overhead added by making some parameter runtime instead of compile-time, but I've not yet done benchmark.